### PR TITLE
Use process.cwd() if opts.rootDir isn't specified.

### DIFF
--- a/index.js
+++ b/index.js
@@ -325,7 +325,7 @@ export type JestResult = {
 */
 
 exports.test = (opts /*: JestOptions */ = {}) => {
-  opts = Object.assign({
+  opts = Object.assign({}, {
     rootDir: process.cwd()
   }, opts);
   return new Promise((resolve, reject) => {

--- a/index.js
+++ b/index.js
@@ -325,6 +325,9 @@ export type JestResult = {
 */
 
 exports.test = (opts /*: JestOptions */ = {}) => {
+  opts = Object.assign({
+    rootDir: process.cwd()
+  }, opts);
   return new Promise((resolve, reject) => {
     jestCli.runCLI(opts, [opts.rootDir], (result /*: JestResult */) => {
       if (result.numFailedTests || result.numFailedTestSuites) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "index.js"
   ],
   "scripts": {
-    "test": "jest --testPathIgnorePatterns /node_modules/,/fixtures/"
+    "test": "jest --testPathIgnorePatterns '(/node_modules/|/fixtures/)'"
   },
   "devDependencies": {
     "flow-bin": "^0.49.1",

--- a/test.js
+++ b/test.js
@@ -28,3 +28,11 @@ test('failure', () => {
     expect(err.numPassedTestSuites).toBe(0);
   });
 });
+
+test('default rootDir', () => {
+  jest.spyOn(process, 'cwd').mockImplementation(() => success);
+  return _jest.test().then(res => {
+    expect(process.cwd.mock.calls.length).toBeGreaterThan(0);
+    process.cwd.mockRestore();
+  });
+});


### PR DESCRIPTION
Also adds a test and fixes the `npm test` command to use a valid ignore pattern.